### PR TITLE
Added Python 3 compatibility

### DIFF
--- a/src/composes/composition/composition_model.py
+++ b/src/composes/composition/composition_model.py
@@ -4,6 +4,7 @@ Created on Oct 5, 2012
 @author: Georgiana Dinu, Pham The Nghia
 '''
 import time
+from six.moves import builtins
 from warnings import warn
 from composes.semantic_space.space import Space
 from composes.matrix.dense_matrix import DenseMatrix
@@ -60,11 +61,9 @@ class CompositionModel(object):
 
         arg1_space, arg2_space = self.extract_arg_spaces(arg_space)
         arg1_list, arg2_list, phrase_list = self.valid_data_to_lists(train_data,
-                                                                     (arg1_space.row2id,
-                                                                      arg2_space.row2id,
-                                                                      phrase_space.row2id)
-                                                                     )
-
+                                                                     arg1_space.row2id,
+                                                                     arg2_space.row2id,
+                                                                     phrase_space.row2id)
 
         self.xxx(arg1_space, arg2_space, phrase_space,
                  arg1_list, arg2_list, phrase_list)
@@ -119,9 +118,9 @@ class CompositionModel(object):
 
         arg1_space, arg2_space = self.extract_arg_spaces(arg_space)
         arg1_list, arg2_list, phrase_list = self.valid_data_to_lists(data,
-                                                                     (arg1_space.row2id,
+                                                                     arg1_space.row2id,
                                                                       arg2_space.row2id,
-                                                                      None))
+                                                                      None)
 
         arg1_mat = arg1_space.get_rows(arg1_list)
         arg2_mat = arg2_space.get_rows(arg2_list)
@@ -132,8 +131,8 @@ class CompositionModel(object):
         if self.composed_id2column is None:
             self.composed_id2column = self._build_id2column(arg1_space, arg2_space)
 
-        log.print_name(logger, self, 1, "\nComposed with composition model:")
-        log.print_info(logger, 3, "Composed total data points:%s" % arg1_mat.shape[0])
+        logger.info("Composed with composition model: %s", self)
+        logger.info("Composed total data points:%s" % arg1_mat.shape[0])
         log.print_matrix_info(logger, composed_phrase_mat, 4,
                               "Resulted (composed) semantic space::")
         log.print_time_info(logger, time.time(), start, 2)
@@ -175,7 +174,7 @@ class CompositionModel(object):
         return arg1_space.id2column
 
 
-    def valid_data_to_lists(self, data, (row2id1, row2id2, row2id3)):
+    def valid_data_to_lists(self, data, row2id1, row2id2, row2id3):
         """
         TO BE MOVED TO A UTILS MODULE!
         """
@@ -184,7 +183,7 @@ class CompositionModel(object):
         list3 = []
 
         j = 0
-        for i in xrange(len(data)):
+        for i in range(len(data)):
             sample = data[i]
 
             cond = True

--- a/src/composes/composition/dilation.py
+++ b/src/composes/composition/dilation.py
@@ -4,7 +4,7 @@ Created on Oct 15, 2012
 @author: Georgiana Dinu, Pham The Nghia
 '''
 import numpy as np
-from composition_model import CompositionModel
+from .composition_model import CompositionModel
 from composes.utils.num_utils import is_numeric
 from composes.utils.py_matrix_utils import nonzero_invert
 

--- a/src/composes/composition/full_additive.py
+++ b/src/composes/composition/full_additive.py
@@ -4,7 +4,7 @@ Created on Oct 5, 2012
 @author: Georgiana Dinu, Pham The Nghia
 '''
 
-from composition_model import CompositionModel
+from .composition_model import CompositionModel
 from composes.utils.gen_utils import assert_is_instance
 from composes.utils.matrix_utils import is_array_or_matrix
 from composes.utils.matrix_utils import padd_matrix

--- a/src/composes/composition/lexical_function.py
+++ b/src/composes/composition/lexical_function.py
@@ -4,9 +4,12 @@ Created on Oct 11, 2012
 @author: Georgiana Dinu, Pham The Nghia
 '''
 
-import numpy as np
 import time
-from composition_model import CompositionModel
+import logging
+
+import numpy as np
+
+from .composition_model import CompositionModel
 from composes.semantic_space.space import Space
 from composes.utils.gen_utils import get_partitions
 from composes.utils.regression_learner import LstsqRegressionLearner
@@ -17,9 +20,8 @@ from composes.utils.matrix_utils import padd_matrix
 from composes.utils.num_utils import is_integer
 from composes.utils.gen_utils import assert_is_instance
 from composes.exception.illegal_state_error import IllegalStateError
-
-import logging
 from composes.utils import log_utils as log
+
 
 logger = logging.getLogger(__name__)
 
@@ -27,13 +29,13 @@ logger = logging.getLogger(__name__)
 class LexicalFunction(CompositionModel):
     """
     Implements the lexical function compositional model.
-
+    
         :math:`\\vec{p} = U \\vec{v}`
-
+     
     where :math:`\\vec{p}` is the vector of the composed phrase,
     :math:`U` is the matrix representation of the first component (the lexical function)
     and :math:`\\vec{v}` is the vector representation of the second component
-
+          
     """
 
     _name = "lexical_function"
@@ -41,16 +43,16 @@ class LexicalFunction(CompositionModel):
     def __init__(self, function_space=None, intercept=False, learner=None, min_samples=1):
         """
         Constructor.
-
+        
         Args:
             function_space= : function space parameter, containing
             the lexical functions, of type Space. Optional, can be set through
             training.
-
+            
             intercept= : True/False, True if the function space has intercept.
-            Optional, default False. When training is used, intercept is set
+            Optional, default False. When training is used, intercept is set 
             to the intercept value of the regression learner used.
-
+        
             learner= : regression method of type RegressionLearner. Optional,
             default LstsqRegressionLearner.
 
@@ -73,28 +75,28 @@ class LexicalFunction(CompositionModel):
     def train(self, train_data, arg_space, phrase_space):
         """
         Trains a lexical function composition model to learn a function
-        space and sets the function_space parameter.
-
+        space and sets the function_space parameter. 
+                
         Args:
-            train_data: list of string tuples. Each tuple contains 3
+            train_data: list of string tuples. Each tuple contains 3 
             string elements: (function_word, arg, phrase).
-
-            arg_space: argument space, of type Space. arg elements of
+            
+            arg_space: argument space, of type Space. arg elements of 
             train data are interpreted in this space.
-
-            phrase space: phrase space, of type Space. phrase elements of
+        
+            phrase space: phrase space, of type Space. phrase elements of 
             the train data are interpreted in this space.
-
-        Training tuples which contain strings not found in their
+            
+        Training tuples which contain strings not found in their 
         respective spaces are ignored. Function words containing less than
         _MIN_SAMPLES training instances are ignored. For example, if
         _MIN_SAMPLES=2 and function word "red" occurs in only one phrase, "red"
         is ignored.
-
+        
         The id2column attribute of the resulted composed space is set to
         be equal to that of the phrase space given as an input.
         """
-
+        logging.info('Starting LexicalFunction training')
         start = time.time()
 
         self._has_intercept = self._regression_learner.has_intercept()
@@ -106,9 +108,9 @@ class LexicalFunction(CompositionModel):
 
         train_data = sorted(train_data, key=lambda tup: tup[0])
         function_word_list, arg_list, phrase_list = self.valid_data_to_lists(train_data,
-                                                                             (None,
-                                                                              arg_space.row2id,
-                                                                              phrase_space.row2id))
+                                                                             None,
+                                                                             arg_space.row2id,
+                                                                             phrase_space.row2id)
         #partitions the sorted input data
         keys, key_ranges = get_partitions(function_word_list, self._MIN_SAMPLES)
 
@@ -122,11 +124,11 @@ class LexicalFunction(CompositionModel):
         else:
             new_element_shape = phrase_space.element_shape + (arg_space.element_shape[0],)
 
-        for i in xrange(len(key_ranges)):
+        for i in range(len(key_ranges)):
             idx_beg, idx_end = key_ranges[i]
 
-            print ("Training lexical function...%s with %d samples"
-                   % (keys[i], idx_end - idx_beg))
+            logger.info("Training lexical function %s with %d samples"
+                        % (keys[i], idx_end - idx_beg))
 
             arg_mat = arg_space.get_rows(arg_list[idx_beg:idx_end])
             phrase_mat = phrase_space.get_rows(phrase_list[idx_beg:idx_end])
@@ -149,46 +151,42 @@ class LexicalFunction(CompositionModel):
         self._function_space = Space(new_space_mat, keys, [],
                                      element_shape=new_element_shape)
 
-        log.print_composition_model_info(logger, self, 1, "\nTrained composition model:")
-        log.print_info(logger, 3, "Trained: %s lexical functions" % len(keys))
-        log.print_info(logger, 3, "With total data points:%s" % len(function_word_list))
-        log.print_matrix_info(logger, arg_space.cooccurrence_matrix, 3,
-                              "Semantic space of arguments:")
-        log.print_info(logger, 3, "Shape of lexical functions learned:%s"
-                                  % (new_element_shape,))
-        log.print_matrix_info(logger, new_space_mat, 3,
-                              "Semantic space of lexical functions:")
+        log.print_composition_model_info(logger, self, "Trained composition model: ")
+        logger.info("Done training %s lexical functions with %s data points" % (len(keys), len(function_word_list)))
+        log.print_matrix_info(logger, arg_space.cooccurrence_matrix, 3, "Semantic space of arguments:")
+        logger.info("Shape of lexical functions learned: %s" % (new_element_shape,))
+        log.print_matrix_info(logger, new_space_mat, 3, "Semantic space of lexical functions:")
         log.print_time_info(logger, time.time(), start, 2)
 
     def compose(self, data, arg_space):
         """
         Uses a lexical function composition model to compose elements.
-
+        
         Args:
             data: data to be composed. List of tuples, each containing 3
-            strings: (function_word, arg, composed_phrase). function_word and
-            arg are the elements to be composed and composed_phrase is the
+            strings: (function_word, arg, composed_phrase). function_word and 
+            arg are the elements to be composed and composed_phrase is the 
             string associated to their composition. function_word elements
-            are interpreted in self.function_space.
-
-            arg_space: argument space, of type Space. arg elements of data are
-            interpreted in this space.
-
+            are interpreted in self.function_space. 
+            
+            arg_space: argument space, of type Space. arg elements of data are 
+            interpreted in this space. 
+        
         Returns:
-            composed space: a new object of type Space, containing the
+            composed space: a new object of type Space, containing the 
             phrases obtained through composition.
-
+            
         """
         start = time.time()
 
         assert_is_instance(arg_space, Space)
         arg1_list, arg2_list, phrase_list = self.valid_data_to_lists(data,
-                                                                     (self._function_space.row2id,
-                                                                      arg_space.row2id,
-                                                                      None))
+                                                                     self._function_space.row2id,
+                                                                     arg_space.row2id,
+                                                                     None)
 
         composed_vec_list = []
-        for i in xrange(len(arg1_list)):
+        for i in range(len(arg1_list)):
             arg1_vec = self._function_space.get_row(arg1_list[i])
             arg2_vec = arg_space.get_row(arg2_list[i])
 
@@ -204,10 +202,10 @@ class LexicalFunction(CompositionModel):
         result_element_shape = self._function_space.element_shape[0:-1]
         composed_ph_mat = composed_ph_vec.nary_vstack(composed_vec_list)
 
-        log.print_name(logger, self, 1, "\nComposed with composition model:")
-        log.print_info(logger, 3, "Composed total data points:%s" % len(arg1_list))
-        log.print_info(logger, 3, "Functional shape of the resulted (composed) elements:%s"
-                                  % (result_element_shape,))
+        logger.info("Composed with composition model: %s", self)
+        logger.info("Composed total data points:%s" % len(arg1_list))
+        logger.info("Functional shape of the resulted (composed) elements:%s"
+                    % (result_element_shape,))
         log.print_matrix_info(logger, composed_ph_mat, 4,
                               "Resulted (composed) semantic space:")
         log.print_time_info(logger, time.time(), start, 2)
@@ -252,7 +250,7 @@ class LexicalFunction(CompositionModel):
 
     function_space = property(get_function_space)
     """
-    Function space parameter, containing the lexical functions, of type Space.
+    Function space parameter, containing the lexical functions, of type Space. 
     Can be set through training or through initialization, default None.
     """
 
@@ -261,8 +259,8 @@ class LexicalFunction(CompositionModel):
 
     has_intercept = property(get_has_intercept)
     """
-    Has intercept parameter, boolean. If True, then the function_space is
-    assumed to contain intercept. Can be set through training or through
+    Has intercept parameter, boolean. If True, then the function_space is 
+    assumed to contain intercept. Can be set through training or through 
     initialization, default is assumed to be False.
     """
 
@@ -284,5 +282,6 @@ class LexicalFunction(CompositionModel):
         if self._function_space is None:
             raise IllegalStateError("cannot export an untrained LexicalFunction model.")
         self._function_space.export(filename, format="dm")
-
-
+            
+        
+            

--- a/src/composes/composition/multiplicative.py
+++ b/src/composes/composition/multiplicative.py
@@ -4,7 +4,7 @@ Created on Oct 5, 2012
 @author: Georgiana Dinu, Pham The Nghia
 '''
 
-from composition_model import CompositionModel
+from .composition_model import CompositionModel
 from composes.exception.illegal_state_error import IllegalOperationError
 
 class Multiplicative(CompositionModel):

--- a/src/composes/composition/weighted_additive.py
+++ b/src/composes/composition/weighted_additive.py
@@ -4,7 +4,7 @@ Created on Oct 5, 2012
 @author: Georgiana Dinu, Pham The Nghia
 '''
 
-from composition_model import CompositionModel
+from .composition_model import CompositionModel
 from composes.matrix.dense_matrix import DenseMatrix
 from composes.utils.num_utils import is_numeric
 # from composes.utils.mem_utils import get_mem_usage
@@ -62,7 +62,6 @@ class WeightedAdditive(CompositionModel):
         if not alpha is None and beta is None:
             self._beta = 1 - self._alpha
 
-
     def xxx(self, arg1_space, arg2_space, phrase_space, arg1_list, arg2_list, phrase_list):
 
         # we try to achieve at most MAX_MEM_OVERHEAD*phrase_space memory overhead
@@ -72,7 +71,7 @@ class WeightedAdditive(CompositionModel):
 
         arg1_arg2_dot, arg1_phrase_dot, arg2_phrase_dot, arg1_norm_sqr, arg2_norm_sqr = (0, 0, 0, 0, 0)
 
-        for i in range(len(arg1_list) / chunk_size):
+        for i in range(int(len(arg1_list) // chunk_size)):
             beg, end = i*chunk_size, min((i+1)*chunk_size, len(arg1_list))
 
             arg1_mat = arg1_space.get_rows(arg1_list[beg:end])

--- a/src/composes/matrix/linalg.py
+++ b/src/composes/matrix/linalg.py
@@ -124,7 +124,7 @@ class Linalg(object):
         try:
             tmp_mat = Linalg.pinv(((matrix_a_t * matrix_a) + lambda_diag))
         except np.linalg.LinAlgError:
-            print "Warning! LinAlgError"
+            print("Warning! LinAlgError")
             tmp_mat = matrix_type.identity(lambda_diag.shape[0])
 
         tmp_res = tmp_mat * matrix_a_t
@@ -234,7 +234,7 @@ class Linalg(object):
     @staticmethod
     def _dense_svd(matrix_, reduced_dimension):
 
-        print "Running dense svd"
+        print("Running dense svd")
         u, s, vt = np.linalg.svd(matrix_.mat, False, True)
         rank = len(s[s > Linalg._SVD_TOL])
 
@@ -277,11 +277,11 @@ class Linalg(object):
 
         #sub_loop_time = time()
 
-        for iteration in xrange(1, maxiter):
+        for iteration in range(1, maxiter):
             grad = w_t_w * h - w_t_v
 
             # search step size
-            for inner_iter in xrange(1, 20):
+            for inner_iter in range(1, 20):
                 hn = h - alpha * grad
                 hn = hn.get_non_negative()
                 d = hn - h
@@ -349,7 +349,7 @@ class Linalg(object):
         tolH = tolW
 
         #loop_time = init_time
-        for iteration in xrange(1, Linalg._NMF_MAX_ITER):
+        for iteration in range(1, Linalg._NMF_MAX_ITER):
             log.print_info(logger, 5, "Iteration: %d(%d)" % (iteration, Linalg._NMF_MAX_ITER))
 
             if time() - init_time > Linalg._NMF_TIME_LIMIT:

--- a/src/composes/matrix/matrix.py
+++ b/src/composes/matrix/matrix.py
@@ -52,6 +52,10 @@ class Matrix(object):
             raise TypeError("expected numeric type, received %s" % (type(factor)))
         return type(self)(self.mat / float(factor))
 
+    def __truediv__(self, other):
+        # python 3
+        return self.__div__(other)
+
     def __rmul__(self, factor):
         ''' * operation'''
         if is_numeric(factor):

--- a/src/composes/semantic_space/peripheral_space.py
+++ b/src/composes/semantic_space/peripheral_space.py
@@ -4,7 +4,7 @@ Created on Sep 26, 2012
 @author: Georgiana Dinu, Pham The Nghia
 '''
 
-from space import Space
+from .space import Space
 from numpy import array
 from composes.utils.space_utils import list2dict
 from composes.utils.space_utils import assert_dict_match_list

--- a/src/composes/transformation/dim_reduction/nmf.py
+++ b/src/composes/transformation/dim_reduction/nmf.py
@@ -5,7 +5,7 @@ Created on Oct 1, 2012
 '''
 
 import numpy as np
-from dimensionality_reduction import DimensionalityReduction
+from .dimensionality_reduction import DimensionalityReduction
 from composes.matrix.linalg import Linalg
 from math import sqrt
 

--- a/src/composes/transformation/dim_reduction/svd.py
+++ b/src/composes/transformation/dim_reduction/svd.py
@@ -4,7 +4,7 @@ Created on Sep 28, 2012
 @author: Georgiana Dinu, Pham The Nghia
 '''
 
-from dimensionality_reduction import DimensionalityReduction
+from .dimensionality_reduction import DimensionalityReduction
 from composes.matrix.linalg import Linalg
 
 class Svd(DimensionalityReduction):

--- a/src/composes/transformation/feature_selection/top_feature_selection.py
+++ b/src/composes/transformation/feature_selection/top_feature_selection.py
@@ -4,7 +4,7 @@ Created on Oct 5, 2012
 @author: Georgiana Dinu, Pham The Nghia
 '''
 from warnings import warn
-from feature_selection import FeatureSelection
+from .feature_selection import FeatureSelection
 
 class TopFeatureSelection(FeatureSelection):
     """

--- a/src/composes/transformation/scaling/epmi_weighting.py
+++ b/src/composes/transformation/scaling/epmi_weighting.py
@@ -1,5 +1,5 @@
 
-from scaling import Scaling
+from .scaling import Scaling
 from composes.utils.py_matrix_utils import nonzero_invert
 
 class EpmiWeighting(Scaling):

--- a/src/composes/transformation/scaling/normalization.py
+++ b/src/composes/transformation/scaling/normalization.py
@@ -5,7 +5,7 @@ Created on Oct 4, 2012
 '''
 from numpy import double
 from warnings import warn
-from scaling import Scaling
+from .scaling import Scaling
 
 class Normalization(Scaling):
     """

--- a/src/composes/transformation/scaling/plmi_weighting.py
+++ b/src/composes/transformation/scaling/plmi_weighting.py
@@ -1,6 +1,6 @@
 
-from scaling import Scaling
-from ppmi_weighting import PpmiWeighting
+from .scaling import Scaling
+from .ppmi_weighting import PpmiWeighting
 
 class PlmiWeighting(Scaling):
     """

--- a/src/composes/transformation/scaling/plog_weighting.py
+++ b/src/composes/transformation/scaling/plog_weighting.py
@@ -1,5 +1,5 @@
 
-from scaling import Scaling
+from .scaling import Scaling
 
 class PlogWeighting(Scaling):
     """

--- a/src/composes/transformation/scaling/ppmi_weighting.py
+++ b/src/composes/transformation/scaling/ppmi_weighting.py
@@ -1,6 +1,6 @@
 
-from scaling import Scaling
-from epmi_weighting import EpmiWeighting
+from .scaling import Scaling
+from .epmi_weighting import EpmiWeighting
 
 class PpmiWeighting(Scaling):
     """

--- a/src/composes/transformation/scaling/row_normalization.py
+++ b/src/composes/transformation/scaling/row_normalization.py
@@ -4,7 +4,7 @@ Created on Oct 4, 2012
 @author: Georgiana Dinu, Pham The Nghia
 '''
 
-from scaling import Scaling
+from .scaling import Scaling
 from composes.utils.py_matrix_utils import nonzero_invert
 
 class RowNormalization(Scaling):

--- a/src/composes/utils/crossvalidation_utils.py
+++ b/src/composes/utils/crossvalidation_utils.py
@@ -17,7 +17,7 @@ def get_split_indices(range_len, fold):
         return get_split_indices(range_len, range_len)
 
     range_ = range(range_len)
-    shuffle(range_)
+    shuffle(list(range_))
     current_index = 0
     for i in range(fold):
         if i < len(range_)%fold:

--- a/src/composes/utils/gen_utils.py
+++ b/src/composes/utils/gen_utils.py
@@ -5,7 +5,7 @@ Created on May 21, 2013
 '''
 from composes.exception.invalid_argument_error import InvalidArgumentError
 
-
+from six.moves import builtins
 def assert_is_instance(object_, class_):
     if not isinstance(object_, class_):
         raise TypeError("expected %s, received %s" % (class_, type(object_)))
@@ -24,6 +24,6 @@ def get_partitions(sorted_list, min_samples):
     if len(sorted_list) - prev_idx >= min_samples:
         range_list.append((prev_idx, len(sorted_list)))
 
-    keys = [sorted_list[range_list[i][0]] for i in xrange(len(range_list))]
+    keys = [sorted_list[range_list[i][0]] for i in range(len(range_list))]
 
     return keys, range_list

--- a/src/composes/utils/matrix_utils.py
+++ b/src/composes/utils/matrix_utils.py
@@ -4,7 +4,7 @@ from composes.matrix.sparse_matrix import SparseMatrix
 from composes.matrix.dense_matrix import DenseMatrix
 from composes.matrix.matrix import Matrix
 from scipy.sparse import issparse
-from py_matrix_utils import is_array
+from composes.utils.py_matrix_utils import is_array
 from warnings import warn
 
 def to_matrix(matrix_):

--- a/src/composes/utils/num_utils.py
+++ b/src/composes/utils/num_utils.py
@@ -5,11 +5,12 @@ Created on Sep 18, 2012
 '''
 
 from numbers import Number
-from numbers import Integral
 import numpy as np
+import six
 
 def is_numeric(operand):
     return isinstance(operand, (Number, np.number))
 
 def is_integer(operand):
-    return isinstance(operand, Integral)
+    return isinstance(operand, six.integer_types) or isinstance(operand, np.integer)
+

--- a/src/composes/utils/space_utils.py
+++ b/src/composes/utils/space_utils.py
@@ -31,7 +31,7 @@ def assert_dict_match_list(dict_, list_):
 
     if not len(list_) == len(dict_):
         raise match_err
-    for (k, v) in dict_.iteritems():
+    for (k, v) in dict_.items():
         if not list_[v] == k:
             raise match_err
 

--- a/src/pipelines/apply_composition.py
+++ b/src/pipelines/apply_composition.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 '''
 Created on Oct 17, 2012
 
@@ -6,7 +7,10 @@ Created on Oct 17, 2012
 
 import sys
 import getopt
-from ConfigParser import ConfigParser
+try:
+    from ConfigParser import ConfigParser # python 2
+except ImportError:
+    from configparser import ConfigParser # python 3
 from composes.semantic_space.space import Space
 from composes.composition.composition_model import CompositionModel
 from composes.composition.dilation import Dilation
@@ -15,14 +19,14 @@ from composes.composition.lexical_function import LexicalFunction
 from composes.composition.multiplicative import Multiplicative
 from composes.utils import io_utils
 from composes.utils import log_utils
-import pipeline_utils as utils
+import pipelines.pipeline_utils as utils
 
 import logging
 logger = logging.getLogger("test vector space construction pipeline")
 
+
 def usage(errno=0):
-    print >>sys.stderr,\
-    """Usage:
+    print("""Usage:
     python apply_composition.py [options] [config_file]
 
     Options:
@@ -51,8 +55,9 @@ def usage(errno=0):
             config_file will be used.
 
     Example:
-    """
+    """)
     sys.exit(errno)
+
 
 def create_model(model, alpha, beta, lambda_):
 
@@ -76,7 +81,7 @@ def create_model(model, alpha, beta, lambda_):
 def apply_model(in_file, out_dir, model, trained_model, arg_space_files,
                 alpha, beta, lambda_, out_format):
 
-    print "Reading in data..."
+    print("Reading in data...")
     in_descr = in_file.split("/")[-1]
 
     if not model is None:
@@ -93,13 +98,13 @@ def apply_model(in_file, out_dir, model, trained_model, arg_space_files,
 
     data = io_utils.read_tuple_list(in_file, fields=[0, 1, 2])
 
-    print "Applying composition model:%s" % model_descr
+    print("Applying composition model:%s" % model_descr)
     if arg_space2 is None or type(model_obj) is LexicalFunction:
         composed_space = model_obj.compose(data, arg_space)
     else:
         composed_space = model_obj.compose(data, (arg_space, arg_space2))
 
-    print "Printing..."
+    print("Printing...")
     out_file = ".".join([out_dir + "/COMPOSED_SS", model_descr, in_descr])
     io_utils.save(composed_space, "%s.pkl" % out_file)
 
@@ -114,8 +119,8 @@ def main(sys_argv):
                                     "alpha=", "beta=", "lambda=", "arg_space=",
                                     "load_model=", "output_format=", "log="])
 
-    except getopt.GetoptError, err:
-        print str(err)
+    except getopt.GetoptError as err:
+        print(str(err))
         usage()
         sys.exit(1)
 
@@ -149,7 +154,7 @@ def main(sys_argv):
         log_file = utils.config_get(section, config, "log", None)
         out_format = utils.config_get(section, config, "output_format", None)
 
-    print opts
+    print(opts)
     for opt, val in opts:
         if opt in ("-i", "--input"):
             in_file = val

--- a/src/pipelines/build_core_space.py
+++ b/src/pipelines/build_core_space.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 '''
 Created on Oct 17, 2012
 
@@ -15,7 +16,10 @@ import sys
 import getopt
 import os
 from warnings import warn
-from ConfigParser import ConfigParser
+try:
+    from ConfigParser import ConfigParser # python 2
+except ImportError:
+    from configparser import ConfigParser # python 3
 from composes.semantic_space.space import Space
 from composes.transformation.scaling.epmi_weighting import EpmiWeighting
 from composes.transformation.scaling.ppmi_weighting import PpmiWeighting
@@ -28,16 +32,14 @@ from composes.transformation.scaling.normalization import Normalization
 from composes.transformation.scaling.row_normalization import RowNormalization
 from composes.utils import io_utils
 from composes.utils import log_utils
-import pipeline_utils as utils
-
+from . import pipeline_utils as utils
 import logging
 logger = logging.getLogger("test vector space construction pipeline")
 
 
 
 def usage(errno=0):
-    print >>sys.stderr,\
-    """
+    print("""
     Usage:
     python build_core_space.py [options] [config_file]
     \n\
@@ -69,7 +71,7 @@ def usage(errno=0):
             config_file will be used. Optional.
 
     Example:
-    """
+    """)
     sys.exit(errno)
 
 
@@ -81,7 +83,7 @@ def apply_weighting(space, w):
                       "plmi":PlmiWeighting()}
 
     if not w in (None, "none"):
-        print "Applying weighting: %s" % w
+        print(("Applying weighting: %s" % w))
         if not w in weightings_dict:
             warn("Weigthing scheme: %s not defined" % w)
             return space
@@ -99,7 +101,7 @@ def apply_selection(w_space, s):
     selection_crit_list = ["sum", "length"]
 
     if not s in (None, "none"):
-        print "Applying feature selection: %s" % s
+        print(("Applying feature selection: %s" % s))
         sel_els = s.split("_")
         if not len(sel_els) == 3:
             warn("Feature selection: %s not defined" % s)
@@ -126,7 +128,7 @@ def apply_reduction(s_space, r):
                        "nmf": Nmf}
 
     if not r in (None, "none"):
-        print "Applying dimensionality reduction: %s" % r
+        print(("Applying dimensionality reduction: %s" % r))
         red_els = r.split("_")
         if not len(red_els) == 2:
             warn("Dimensionality reduction: %s not defined" % r)
@@ -149,7 +151,7 @@ def apply_normalization(r_space, n):
                            "row": RowNormalization}
 
     if not n in (None, "none"):
-        print "Applying normalization: %s" % n
+        print("Applying normalization: %s" % n)
         if not n in normalizations_dict:
             warn("Normalization: %s not defined" % n)
             return r_space
@@ -198,7 +200,7 @@ def build_spaces(in_file_prefix, in_format, out_dir, out_format, weightings,
                                  % column_file)
             column_file = None
 
-        print "Building matrix..."
+        print("Building matrix...")
         space = Space.build(data=data_file, rows=row_file, cols=column_file,
                             format=in_format)
 
@@ -214,7 +216,7 @@ def build_spaces(in_file_prefix, in_format, out_dir, out_format, weightings,
                 for n in normalizations:
                     n_space = apply_normalization(r_space, n)
 
-                    print "Printing..."
+                    print("Printing...")
                     print_space(n_space, out_dir, [in_file_descr, w, s, r, n], out_format)
 
 
@@ -226,8 +228,8 @@ def main(sys_argv):
                                     "weighting=", "selection=", "reduction=",
                                      "normalization=", "log=", "gz=",
                                      "input_format=", "output_format="])
-    except getopt.GetoptError, err:
-        print str(err)
+    except getopt.GetoptError as err:
+        print(str(err))
         usage()
         sys.exit(1)
 

--- a/src/pipelines/build_peripheral_space.py
+++ b/src/pipelines/build_peripheral_space.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 '''
 Created on Oct 17, 2012
 
@@ -10,23 +11,25 @@ Created on Jun 12, 2012
 @author: thenghia.pham
 '''
 
-
 import sys
 import getopt
 import os
-from ConfigParser import ConfigParser
+try:
+    from ConfigParser import ConfigParser # python 2
+except ImportError:
+    from configparser import ConfigParser # python 3
 from composes.semantic_space.peripheral_space import PeripheralSpace
 from composes.semantic_space.space import Space
 from composes.utils import io_utils
 from composes.utils import log_utils
-import pipeline_utils as utils
+import pipelines.pipeline_utils as utils
 
 import logging
 logger = logging.getLogger("test vector space construction pipeline")
 
 
 def usage(errno=0):
-    print >>sys.stderr,\
+    print(
     """Usage:
     python build_peripheral_space.py [options] [config_file]
     \n\
@@ -51,7 +54,7 @@ def usage(errno=0):
             config_file will be used.
 
     Example:
-    """
+    """)
     sys.exit(errno)
 
 
@@ -76,7 +79,7 @@ def build_raw_per_space(in_file_prefix, in_format, is_gz):
             if in_format == "sm":
                 raise ValueError("Column file: %s needs to be provided!" % column_file)
             column_file = None
-        print "Building matrix..."
+        print("Building matrix...")
         space = Space.build(data=data_file, rows=row_file, cols=column_file, format=in_format)
 
     return space
@@ -97,7 +100,7 @@ def transform_raw_per_space(raw_per_space, in_file_prefix, out_dir, out_format, 
     space = PeripheralSpace(core_space, raw_per_space.cooccurrence_matrix,
                             raw_per_space.id2row, raw_per_space.row2id)
 
-    print "Printing..."
+    print("Printing...")
     out_file_prefix = "%s/%s.%s" % (out_dir, in_file_descr, core_descr)
     io_utils.save(space, out_file_prefix + ".pkl")
     if not out_format is None:
@@ -117,7 +120,7 @@ def build_space_batch(in_file_prefix, in_format, out_dir, out_format,
 
     for file_ in os.listdir(core_in_dir):
         if file_.find(core_filter) != -1 and file_.endswith(".pkl"):
-            print file_
+            print(file_)
             core_space_file = core_in_dir + file_
             transform_raw_per_space(raw_per_space, in_file_prefix, out_dir, out_format, core_space_file)
 
@@ -128,8 +131,8 @@ def main(sys_argv):
                                    ["help", "input=", "output=", "core=",
                                     "log=", "input_format=", "output_format=",
                                     "core_in_dir=", "core_filter=", "gz="])
-    except getopt.GetoptError, err:
-        print str(err)
+    except getopt.GetoptError as err:
+        print(str(err))
         usage()
         sys.exit(1)
 

--- a/src/pipelines/compute_neighbours.py
+++ b/src/pipelines/compute_neighbours.py
@@ -18,7 +18,10 @@ Created on Jun 12, 2012
 
 import sys
 import getopt
-from ConfigParser import ConfigParser
+try:
+    from ConfigParser import ConfigParser # python 2
+except ImportError:
+    from configparser import ConfigParser # python 3
 from composes.semantic_space.space import Space
 from composes.similarity.cos import CosSimilarity
 from composes.similarity.lin import LinSimilarity
@@ -26,7 +29,7 @@ from composes.similarity.dot_prod import DotProdSimilarity
 from composes.similarity.euclidean import EuclideanSimilarity
 from composes.utils import io_utils
 from composes.utils import log_utils
-import pipeline_utils as utils
+import pipelines.pipeline_utils as utils
 import logging
 logger = logging.getLogger("test vector space construction pipeline")
 
@@ -82,7 +85,7 @@ def compute_neighbours(in_file, no_neighbours, out_dir, sim_measure, space_files
 
     data = io_utils.read_list(in_file)
 
-    print "Computing neighbours: %s" % sim_measure
+    print("Computing neighbours: %s" % sim_measure)
     with open(out_file,"w") as out_stream:
         for word in data:
             out_stream.write("%s\n" % word)
@@ -95,8 +98,8 @@ def main(sys_argv):
         opts, argv = getopt.getopt(sys_argv[1:], "hi:o:s:m:n:l:",
                                    ["help", "input=", "output=", "sim_measures=",
                                     "space=", "log=", "no_neighbours="])
-    except getopt.GetoptError, err:
-        print str(err)
+    except getopt.GetoptError as err:
+        print(str(err))
         usage()
         sys.exit(1)
 

--- a/src/pipelines/compute_similarities.py
+++ b/src/pipelines/compute_similarities.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 '''
 Created on Oct 17, 2012
 
@@ -20,7 +21,10 @@ import sys
 import os
 import getopt
 from warnings import warn
-from ConfigParser import ConfigParser
+try:
+    from ConfigParser import ConfigParser # python 2
+except ImportError:
+    from configparser import ConfigParser # python 3
 from composes.semantic_space.space import Space
 from composes.similarity.cos import CosSimilarity
 from composes.similarity.lin import LinSimilarity
@@ -28,16 +32,14 @@ from composes.similarity.dot_prod import DotProdSimilarity
 from composes.similarity.euclidean import EuclideanSimilarity
 from composes.utils import io_utils
 from composes.utils import log_utils
-import pipeline_utils as utils
+import pipelines.pipeline_utils as utils
 
 import logging
 logger = logging.getLogger("test vector space construction pipeline")
 
 
-
 def usage(errno=0):
-    print >>sys.stderr,\
-    """Usage:
+    print("""Usage:
     python compute_similarities.py [options] [config_file]
 
     Options:
@@ -60,7 +62,7 @@ def usage(errno=0):
             config_file will be used.
 
     Example:
-    """
+    """)
     sys.exit(errno)
 
 
@@ -76,7 +78,7 @@ def compute_sim_batch(in_file, columns, out_dir, sim_measures, in_dir):
         if file_.endswith(".pkl"):
             space_file = in_dir + file_
 
-            print space_file
+            print(space_file)
             compute_sim(in_file, columns, out_dir, sim_measures, [space_file])
 
 
@@ -108,7 +110,7 @@ def compute_sim(in_file, columns, out_dir, sim_measures, space_files):
     descr = ".".join(["SIMS", in_file.split("/")[-1], space_descr])
 
     for sim_measure in sim_measures:
-        print "Computing similarities: %s" % sim_measure
+        print("Computing similarities: %s" % sim_measure)
         if not sim_measure in sim_dict:
             warn("Similarity measure:%s not defined" % sim_measure)
             continue
@@ -133,8 +135,8 @@ def main(sys_argv):
         opts, argv = getopt.getopt(sys_argv[1:], "hi:o:s:m:c:l:",
                                    ["help", "input=", "output=", "sim_measures=",
                                     "space=", "in_dir=", "columns=", "log=" ])
-    except getopt.GetoptError, err:
-        print str(err)
+    except getopt.GetoptError as err:
+        print(str(err))
         usage()
         sys.exit(1)
 

--- a/src/pipelines/evaluate_similarities.py
+++ b/src/pipelines/evaluate_similarities.py
@@ -19,10 +19,13 @@ Created on Jun 12, 2012
 import sys
 import getopt
 import os
-from ConfigParser import ConfigParser
+try:
+    from ConfigParser import ConfigParser # python 2
+except ImportError:
+    from configparser import ConfigParser # python 3
 from composes.utils import scoring_utils
 from composes.utils import log_utils
-import pipeline_utils as utils
+from . import pipeline_utils as utils
 
 import logging
 logger = logging.getLogger("test vector space construction pipeline")
@@ -30,8 +33,7 @@ logger = logging.getLogger("test vector space construction pipeline")
 
 
 def usage(errno=0):
-    print >>sys.stderr,\
-    """Usage:
+    print("""Usage:
     python compute_similarities.py [options] [config_file]
 
     Options:
@@ -53,8 +55,9 @@ def usage(errno=0):
             config_file will be used.
 
     Example:
-    """
+    """)
     sys.exit(errno)
+
 
 def evaluate_sim(in_file, columns, corr_measures):
 
@@ -73,9 +76,9 @@ def evaluate_sim(in_file, columns, corr_measures):
                 prediction.append(float(elems[col1]))
 
     for corr_measure in corr_measures:
-        print "CORRELATION:%s" % corr_measure
+        print("CORRELATION:%s" % corr_measure)
         corr = scoring_utils.score(gold, prediction, corr_measure)
-        print "\t%f" % corr
+        print("\t%f" % corr)
 
 
 def evaluate_sim_batch(in_dir, columns, corr_measures, filter_=""):
@@ -88,7 +91,7 @@ def evaluate_sim_batch(in_dir, columns, corr_measures, filter_=""):
 
     for file_ in os.listdir(in_dir):
         if file_.find(filter_) != -1:
-            print file_
+            print(file_)
             evaluate_sim(in_dir + file_, columns, corr_measures)
 
 
@@ -98,8 +101,8 @@ def main(sys_argv):
                                    ["help", "input=", "correlation_measure=",
                                     "columns=", "log=", "in_dir=", "filter="])
 
-    except getopt.GetoptError, err:
-        print str(err)
+    except getopt.GetoptError as err:
+        print(str(err))
         usage()
         sys.exit(1)
 

--- a/src/pipelines/pipeline_utils.py
+++ b/src/pipelines/pipeline_utils.py
@@ -6,17 +6,17 @@ Created on Oct 20, 2012
 
 def assert_bool(option, message, usage):
     if option not in (True, False):
-        print message
+        print(message)
         usage(1)
 
 def assert_option_not_none(option, message, usage):
     if option is None:
-        print message
+        print(message)
         usage(1)
 
 def assert_xor_options(option1, option2, message, usage):
     if not ((option1 is None) ^ (option2 is None)):
-        print message
+        print(message)
         usage(1)
 
 def config_get(section, config, option, default):

--- a/src/pipelines/train_composition.py
+++ b/src/pipelines/train_composition.py
@@ -18,7 +18,10 @@ Created on Jun 12, 2012
 
 import sys
 import getopt
-from ConfigParser import ConfigParser
+try:
+    from ConfigParser import ConfigParser # python 2
+except ImportError:
+    from configparser import ConfigParser # python 3
 from composes.semantic_space.space import Space
 from composes.composition.dilation import Dilation
 from composes.composition.full_additive import FullAdditive
@@ -28,7 +31,7 @@ from composes.utils.regression_learner import RidgeRegressionLearner
 from composes.utils.regression_learner import LstsqRegressionLearner
 from composes.utils import io_utils
 from composes.utils import log_utils
-import pipeline_utils as utils
+import pipelines.pipeline_utils as utils
 
 import logging
 logger = logging.getLogger("test vector space construction pipeline")
@@ -74,7 +77,7 @@ def usage(errno=0):
 def train_model(in_file, out_dir, model, arg_space_files, phrase_space_file, regression,
                 crossvalid, intercept, param, param_range, export_params):
 
-    print "Reading in data..."
+    print("Reading in data...")
     in_descr = in_file.split("/")[-1]
 
     model_dict = {"weighted_add": WeightedAdditive,
@@ -115,13 +118,13 @@ def train_model(in_file, out_dir, model, arg_space_files, phrase_space_file, reg
 
     train_data = io_utils.read_tuple_list(in_file, fields=[0, 1, 2])
 
-    print "Training %s model" % model
+    print("Training %s model" % model)
     if arg_space2 is None or model == "lexical_func":
         model_obj.train(train_data, arg_space, phrase_space)
     else:
         model_obj.train(train_data, (arg_space, arg_space2), phrase_space)
 
-    print "Printing..."
+    print("Printing...")
     out_file = ".".join([out_dir + "/TRAINED_COMP_MODEL", model, in_descr])
     io_utils.save(model_obj, "%s.pkl" % out_file)
 
@@ -136,8 +139,8 @@ def main(sys_argv):
                                     "regression=", "intercept=", "arg_space=",
                                     "phrase_space=", "export_params=", "log=",
                                     "crossvalidation=", "lambda_range=", "lambda="])
-    except getopt.GetoptError, err:
-        print str(err)
+    except getopt.GetoptError as err:
+        print(str(err))
         usage()
         sys.exit(1)
 

--- a/src/unitest/bcs_pipeline_test.py
+++ b/src/unitest/bcs_pipeline_test.py
@@ -162,10 +162,10 @@ class Test(unittest.TestCase):
                   "--gz", "True"
                   ])
 
-        s1 = Space.build(data = self.dir_ + "mat2.dm", format = "dm")
-        s2 = Space.build(data = self.dir_ + "CORE_SS.mat2.dm", format="dm")
+        s1 = Space.build(data=self.dir_ + "mat2.dm", format="dm")
+        s2 = Space.build(data=self.dir_ + "CORE_SS.mat2.dm", format="dm")
         s3 = io_utils.load(self.dir_ + "CORE_SS.mat2.pkl", Space)
-        s4 = Space.build(data = self.dir_ + "mat2.dm.gz", format = "dm")
+        s4 = Space.build(data=self.dir_ + "mat2.dm.gz", format="dm")
 
         self._test_equal_spaces_dense(s1, s2)
         self._test_equal_spaces_dense(s1, s3)

--- a/src/unitest/dimensionality_reduction_test.py
+++ b/src/unitest/dimensionality_reduction_test.py
@@ -43,8 +43,8 @@ class DimReductionTest(unittest.TestCase):
             #print hd_mat.mat
             #print ws_mat.mat.todense()
             #print hs_mat.mat.todense()
-            print "V:", in_mat
-            print "WH:", (ws_mat*hs_mat).mat.todense()
+            print("V:", in_mat)
+            print("WH:", (ws_mat*hs_mat).mat.todense())
 
             np.testing.assert_array_almost_equal(wd_mat.mat,
                                                  ws_mat.mat.todense(), 2)


### PR DESCRIPTION
Requires `six`, but no code modifications. Also cleaned up Space (using default arguments)

I tried to change existing APIs only when absolutely necessary. I think the only function signature that changes is `valid_data_to_lists` in `composition_model` (as implicit tuple unpacking is no longer supported). Additionally, the following has been changed:
- all IO is done in unicode instead of byte streams (files are opened in `r` mode instead of `br`)
- print is now a function. On a side note, printing to stdout shouldn't be done, especially give that logging is already set up for most of the modules.
- using explicit relative imports
- division changes from integer to float. For matrix-float division to work the magic method `__div__` in `Matrix` needs to be called `__truediv__`
